### PR TITLE
Add ability to compile static libraries

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -71,6 +71,9 @@ function getDependencies(config, callback) {
       callback(err);
       return;
     }
+    if (config.static && config.static.length) {
+      paths = config.static.concat(paths);
+    }
     callback(null, config, paths);
   });
 }


### PR DESCRIPTION
It's impossible right now to compile static libraries (e.g jquery, underscrore, etc) using closure-util, it just cuts them out and compiles only closure dependencies. This change allows to add all static libraries to config.static: [] and they all will be prepended to bundle file.
